### PR TITLE
Bug#434299:When grouping with tag , if it contains the '-' character,…

### DIFF
--- a/Microsoft.RestApi.RestSplitter/Utility.cs
+++ b/Microsoft.RestApi.RestSplitter/Utility.cs
@@ -156,7 +156,7 @@
         public static string ExtractPascalFileNameByRegex(string name, List<string> noSplitWords, string splitChar)
         {
             var result = new List<string>();
-            foreach (var child in name.Split(' ', '_'))
+            foreach (var child in name.Split(' ', '_','-'))
             {
                 var p = string.Format(Pattern, string.Join("|", noSplitWords?.Count > 0 ? Keyword.Concat(noSplitWords).Distinct() : Keyword));
                 var temp = child;


### PR DESCRIPTION
… the word segmentation error will occur.